### PR TITLE
make local work properly in absence of CLI source args, or STDIN list

### DIFF
--- a/cfsync.ini
+++ b/cfsync.ini
@@ -1,26 +1,22 @@
 [api]
 #Your Swift/Cloudfiles username (For rackspace cloud this should be your Rackspace cloud Username)
-username=darrenbirkett
+username=YOUR_USERNAME
 #Your Swift/Cloudfiles API Key
-key=61d4b1285b1087cc7b1be54b20acc1b9
-
+key=YOUR_APIKEY
 
 # Your swift storage auth endpoint
 # For Rackspace Cloud Files
 # UK = https://lon.auth.api.rackspacecloud.com/v1.0
 # US = https://auth.api.rackspacecloud.com/v1.0
-
 url=https://lon.auth.api.rackspacecloud.com/v1.0
 
 [source]
 # The default source directory
-source=/mnt/ter1/pagga
+source=/YOUR/SOURCE/DIRECTORY
 
 [destination]
 # The default destination contianer
-container=testcontainer
-
-
+container=backups
 
 [general]
 md5=False

--- a/cfsync.ini
+++ b/cfsync.ini
@@ -1,8 +1,9 @@
 [api]
 #Your Swift/Cloudfiles username (For rackspace cloud this should be your Rackspace cloud Username)
-username=YOUR_USERNAME
+username=darrenbirkett
 #Your Swift/Cloudfiles API Key
-key=YOUR_APIKEY
+key=61d4b1285b1087cc7b1be54b20acc1b9
+
 
 # Your swift storage auth endpoint
 # For Rackspace Cloud Files
@@ -11,10 +12,16 @@ key=YOUR_APIKEY
 
 url=https://lon.auth.api.rackspacecloud.com/v1.0
 
+[source]
+# The default source directory
+source=/mnt/ter1/pagga
+
 [destination]
 # The default destination contianer
-container=backups
+container=testcontainer
+
+
 
 [general]
-verbose = True
-md5 = True
+md5=False
+verbose=True

--- a/cfsync.py
+++ b/cfsync.py
@@ -19,6 +19,7 @@ class Config:
         self.get('api','username','api_username',True)
         self.get('api','key','api_key',True)
         self.get('api','url','api_url',True)
+	self.get('source','source','source_local',True)
         self.checkApi()
         self.get('destination','container','container_name',True)
         #TODO return contianer object ?
@@ -43,6 +44,7 @@ class Config:
                 self.config['dir'] = 'to'
         except:
             # We didn't get any cli options
+	    self.config['local'] = self.config['source_local'] 
             self.config['dir'] = 'to'
         if(self.config['gen_verbose'] == True):
             print 'Container = ' + self.config['container_name']


### PR DESCRIPTION
I've added a section to the cfsync.ini where you specify the default source dir.  In cfsync.py, it now reads this in if there are no CLI args for source/dest, or an STDIN list. You can probably do it better but it seems to work.
